### PR TITLE
INTERLOK-3294 Upgrade interlok cassandra dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
   slf4jVersion = '2.0.9'
   log4j2Version = '2.13.2'
   mockitoVersion = '5.2.0'
-  cassandraVersion = '3.11.5'
+  cassandraVersion = '4.17.0'
   nettyVersion = '4.1.97.Final'
   jacksonVersion = '2.15.2'
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
@@ -154,18 +154,8 @@ dependencies {
   api ("com.adaptris:interlok-core:$interlokCoreVersion") { changing= true}
   api ("com.adaptris:interlok-common:$interlokCoreVersion") { changing= true}
   implementation ("org.slf4j:slf4j-api:$slf4jVersion")
-  api ("com.datastax.cassandra:cassandra-driver-core:$cassandraVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.google.guava", module: "guava"
-    exclude group : "io.netty"
-  }
-  api ("com.datastax.cassandra:cassandra-driver-mapping:$cassandraVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.google.guava", module: "guava"
-    exclude group : "io.netty"
-  }
+  api ("com.datastax.oss:java-driver-core:$cassandraVersion")
+  api ("com.datastax.oss:java-driver-mapper-runtime:$cassandraVersion")
 
   // Minimal netty specification
   implementation ("io.netty:netty-handler:$nettyVersion")

--- a/src/main/java/com/adaptris/core/cassandra/CassandraConnection.java
+++ b/src/main/java/com/adaptris/core/cassandra/CassandraConnection.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisConnectionImp;
 import com.adaptris.core.CoreException;
@@ -101,6 +102,7 @@ public class CassandraConnection extends AdaptrisConnectionImp {
    * @param localDatacenter
    *          the local datacenter name to use for this Cassandra node
    */
+  @InputFieldDefault("datacenter1")
   @Getter
   @Setter
   private String localDatacenter;

--- a/src/main/java/com/adaptris/core/cassandra/CassandraConnection.java
+++ b/src/main/java/com/adaptris/core/cassandra/CassandraConnection.java
@@ -1,5 +1,11 @@
 package com.adaptris.core.cassandra;
 
+import java.net.InetSocketAddress;
+
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -8,11 +14,14 @@ import com.adaptris.core.AdaptrisConnectionImp;
 import com.adaptris.core.CoreException;
 import com.adaptris.interlok.util.Closer;
 import com.adaptris.security.password.Password;
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Host;
-import com.datastax.driver.core.Metadata;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.shaded.guava.common.net.HostAndPort;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * <p>
@@ -62,81 +71,38 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @DisplayOrder(order = { "connectionUrl", "keyspace", "username", "password" })
 public class CassandraConnection extends AdaptrisConnectionImp {
 
-  private transient Cluster cluster;
+  static final int DEFAULT_PORT = 9042;
+  static final String DEFAULT_DATACENTER_NAME = "datacenter1";
 
-  private transient Session session;
-
-  private String connectionUrl;
-
-  private String keyspace;
-
-  private String username;
-  @InputFieldHint(style = "PASSWORD")
-  private String password;
-
-  @Override
-  protected void prepareConnection() throws CoreException {
-  }
-
-  @Override
-  protected void closeConnection() {
-    setCluster(null);
-  }
-
-  @Override
-  protected void initConnection() throws CoreException {
-  }
-
-  @Override
-  protected void startConnection() throws CoreException {
-    try {
-      setCluster(Cluster.builder()
-          .addContactPoint(getConnectionUrl())
-          .withCredentials(getUsername(), Password.decode(getPassword()))
-          .build());
-      Metadata metadata = cluster.getMetadata();
-      log.debug("Connected to cluster: {}", metadata.getClusterName());
-      for (Host host : metadata.getAllHosts()) {
-        log.debug("Datatacenter: {} Host: {} Rack: {}", host.getDatacenter(), host.getEndPoint().resolve().getAddress(), host.getRack());
-      }
-      setSession(getCluster().connect(getKeyspace()));
-    } catch (Exception ex) {
-      throw new CoreException(ex);
-    }
-  }
-
-  @Override
-  protected void stopConnection() {
-    Closer.closeQuietly(cluster);
-  }
-
-  public String getConnectionUrl() {
-    return connectionUrl;
-  }
+  @Getter
+  private transient CqlSession session;
 
   /**
    * <p>
-   * Sets the connection string to use for this Cassandra source. e.g. localhost
+   * Sets the connection string to use for this Cassandra source. e.g. localhost, localhost:9042. The default port '9042' is used if the
+   * port is specified.
    * </p>
    *
    * @param connectionUrl
    *          the connection string to use for this Cassandra source
    */
-  public void setConnectionUrl(String connectionUrl) {
-    this.connectionUrl = connectionUrl;
-  }
-
-  public Cluster getCluster() {
-    return cluster;
-  }
-
-  public void setCluster(Cluster cluster) {
-    this.cluster = cluster;
-  }
-
-  public String getKeyspace() {
-    return keyspace;
-  }
+  @NotBlank
+  @Getter
+  @Setter
+  private String connectionUrl;
+  
+  /**
+   * <p>
+   * Sets the Cassandra datacenter that is considered "local" by the load balancing policy.
+   * If left empty the default 'datacenter1' will be used.
+   * </p>
+   *
+   * @param localDatacenter
+   *          the local datacenter name to use for this Cassandra node
+   */
+  @Getter
+  @Setter
+  private String localDatacenter;
 
   /**
    * <p>
@@ -147,26 +113,18 @@ public class CassandraConnection extends AdaptrisConnectionImp {
    * @param keyspace
    *          the keyspace to use for this Cassandra node
    */
-  public void setKeyspace(String keyspace) {
-    this.keyspace = keyspace;
-  }
-
-  public String getUsername() {
-    return username;
-  }
+  @Getter
+  @Setter
+  private String keyspace;
 
   /**
    * Set the username used to access the Cassandra database.
    *
    * @param username
    */
-  public void setUsername(String username) {
-    this.username = username;
-  }
-
-  public String getPassword() {
-    return password;
-  }
+  @Getter
+  @Setter
+  private String username;
 
   /**
    * Set the password used to access the Cassandra database.
@@ -174,15 +132,58 @@ public class CassandraConnection extends AdaptrisConnectionImp {
    * @param password
    *          the password which might be encoded using an available password scheme from {@link com.adaptris.security.password.Password}
    */
-  public void setPassword(String password) {
-    this.password = password;
+  @InputFieldHint(style = "PASSWORD")
+  @Getter
+  @Setter
+  private String password;
+
+  @Override
+  protected void prepareConnection() throws CoreException {
   }
 
-  public Session getSession() {
-    return session;
+  @Override
+  protected void closeConnection() {
+    setSession(null);
   }
 
-  public void setSession(Session session) {
+  @Override
+  protected void initConnection() throws CoreException {
+  }
+
+  @Override
+  protected void startConnection() throws CoreException {
+    try {
+      HostAndPort hostAndPort = hostAndPort();
+      session = CqlSession.builder()
+          .addContactPoint(InetSocketAddress.createUnresolved(hostAndPort.getHost(), hostAndPort.getPortOrDefault(DEFAULT_PORT)))
+          .withLocalDatacenter(localDatacenter())
+          .withAuthCredentials(getUsername(), Password.decode(getPassword()))
+          .withKeyspace(getKeyspace())
+          .build();
+      Metadata metadata = session.getMetadata();
+      log.debug("Connected to cluster: {}", metadata.getClusterName());
+      for (Node node : metadata.getNodes().values()) {
+        log.debug("Datatacenter: {} Host: {} Rack: {}", node.getDatacenter(), node.getEndPoint().resolve().toString(), node.getRack());
+      }
+    } catch (Exception ex) {
+      throw new CoreException(ex);
+    }
+  }
+
+  HostAndPort hostAndPort() {
+    return HostAndPort.fromString(getConnectionUrl());
+  }
+  
+  private String localDatacenter() {
+    return StringUtils.defaultIfBlank(getLocalDatacenter(), DEFAULT_DATACENTER_NAME);
+  }
+
+  @Override
+  protected void stopConnection() {
+    Closer.closeQuietly(session);
+  }
+
+  private void setSession(CqlSession session) {
     this.session = session;
   }
 

--- a/src/main/java/com/adaptris/core/cassandra/CassandraExecuteService.java
+++ b/src/main/java/com/adaptris/core/cassandra/CassandraExecuteService.java
@@ -11,8 +11,8 @@ import com.adaptris.core.cassandra.params.NullStatementPrimer;
 import com.adaptris.core.cassandra.params.StatementPrimer;
 import com.adaptris.core.services.jdbc.StatementParameterList;
 import com.adaptris.interlok.config.DataInputParameter;
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -24,8 +24,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Typical uses will be for inserting and deleting rows the databases tables.
  * </p>
  * <p>
- * Specify the source of the CQL statement by configuring a {@link DataInputParameter}. Note that the CQL statement can contain
- * parameters in one of 2 forms; the standard SQL form, using the character "?", or you can use named parameters. <br/>
+ * Specify the source of the CQL statement by configuring a {@link DataInputParameter}. Note that the CQL statement can contain parameters
+ * in one of 2 forms; the standard SQL form, using the character "?", or you can use named parameters. <br/>
  * If you configure any parameters, using the standard SQL form, then you will need to configure a
  * {@link com.adaptris.core.cassandra.params.SequentialParameterApplicator}, or should you wish to name your parameters for ease of
  * configuration, especially when statements contain many parameters, then you will need to configure a
@@ -35,10 +35,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * To configure the values of the parameters configure a {@link StatementParameterList}.
  * </p>
  * <p>
- * You may also configure a {@link StatementPrimer}. Statement Primers are used to prepare a CQL statement before it is executed.
- * <br/>
- * Especially useful may be the {@link CachedStatementPrimer}. The default value for this service is the
- * {@link NullStatementPrimer}.
+ * You may also configure a {@link StatementPrimer}. Statement Primers are used to prepare a CQL statement before it is executed. <br/>
+ * Especially useful may be the {@link CachedStatementPrimer}. The default value for this service is the {@link NullStatementPrimer}.
  * </p>
  * <p>
  * Finally there are expected to be no results for any CQL statement executed, therefore any results are ignored.
@@ -61,8 +59,8 @@ public class CassandraExecuteService extends CassandraServiceImp implements Conn
   }
 
   @Override
-  public void doCassandraService(Session session, AdaptrisMessage message) throws Exception {
-    BoundStatement boundStatement = getParameterApplicator().applyParameters(session, message, getParameterList(), getStatement().extract(message));
+  public void doCassandraService(CqlSession session, AdaptrisMessage message) throws Exception {
+    BoundStatement boundStatement = getParameterApplicator().applyParameters(session, message, getParameterList(),getStatement().extract(message));
     session.execute(boundStatement);
   }
 

--- a/src/main/java/com/adaptris/core/cassandra/CassandraQueryService.java
+++ b/src/main/java/com/adaptris/core/cassandra/CassandraQueryService.java
@@ -18,9 +18,9 @@ import com.adaptris.core.services.jdbc.StatementParameterList;
 import com.adaptris.core.services.jdbc.XmlPayloadTranslator;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.jdbc.JdbcResult;
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -28,12 +28,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Built for Cassandra version 3.0+
  * </p>
  * <p>
- * This service allows us to fire CQL (Cassandra Query Language) queries at a Cassandra cluster, the results of which can be stored
- * into the {@link AdaptrisMessage}.
+ * This service allows us to fire CQL (Cassandra Query Language) queries at a Cassandra cluster, the results of which can be stored into the
+ * {@link AdaptrisMessage}.
  * </p>
  * <p>
- * Specify the source of the CQL statement by configuring a {@link DataInputParameter}. Note that the CQL statement can contain
- * parameters in one of 2 forms; the standard SQL form, using the character "?", or you can use named parameters. <br/>
+ * Specify the source of the CQL statement by configuring a {@link DataInputParameter}. Note that the CQL statement can contain parameters
+ * in one of 2 forms; the standard SQL form, using the character "?", or you can use named parameters. <br/>
  * If you configure any parameters, using the standard SQL form, then you will need to configure a
  * {@link com.adaptris.core.cassandra.params.SequentialParameterApplicator}, or should you wish to name your parameters for ease of
  * configuration, especially when statements contain many parameters, then you will need to configure a
@@ -43,14 +43,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * To configure the values of the parameters configure a {@link StatementParameterList}.
  * </p>
  * <p>
- * You may also configure a {@link StatementPrimer}. Statement Primers are used to prepare a CQL statement before it is executed.
- * <br/>
- * Especially useful may be the {@link CachedStatementPrimer}. The default value for this service is the
- * {@link NullStatementPrimer}.
+ * You may also configure a {@link StatementPrimer}. Statement Primers are used to prepare a CQL statement before it is executed. <br/>
+ * Especially useful may be the {@link CachedStatementPrimer}. The default value for this service is the {@link NullStatementPrimer}.
  * </p>
  * <p>
- * Finally the results of the query can be stored in the {@link AdaptrisMessage}, the format and location of which can be configured
- * using {@link ResultSetTranslator}.
+ * Finally the results of the query can be stored in the {@link AdaptrisMessage}, the format and location of which can be configured using
+ * {@link ResultSetTranslator}.
  * </p>
  *
  * @author amcgrath
@@ -76,7 +74,7 @@ public class CassandraQueryService extends CassandraServiceImp implements Connec
   }
 
   @Override
-  public void doCassandraService(Session session, AdaptrisMessage message) throws Exception {
+  public void doCassandraService(CqlSession session, AdaptrisMessage message) throws Exception {
     BoundStatement boundStatement = getParameterApplicator().applyParameters(session, message, getParameterList(), getStatement().extract(message));
     ResultSet results = session.execute(boundStatement);
 

--- a/src/main/java/com/adaptris/core/cassandra/CassandraServiceImp.java
+++ b/src/main/java/com/adaptris/core/cassandra/CassandraServiceImp.java
@@ -17,7 +17,7 @@ import com.adaptris.core.cassandra.params.StatementPrimer;
 import com.adaptris.core.services.jdbc.StatementParameterList;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.config.DataInputParameter;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
 
 /**
  * <p>
@@ -54,14 +54,14 @@ public abstract class CassandraServiceImp extends ServiceImp implements Connecte
   @Override
   public void doService(AdaptrisMessage message) throws ServiceException {
     try {
-      Session session = getConnection().retrieveConnection(CassandraConnection.class).getSession();
+      CqlSession session = getConnection().retrieveConnection(CassandraConnection.class).getSession();
       doCassandraService(session, message);
-    } catch(Exception ex) {
+    } catch (Exception ex) {
       throw new ServiceException(ex);
     }
   }
 
-  protected abstract void doCassandraService(Session session, AdaptrisMessage message) throws Exception;
+  protected abstract void doCassandraService(CqlSession session, AdaptrisMessage message) throws Exception;
 
   @Override
   public void prepare() throws CoreException {

--- a/src/main/java/com/adaptris/core/cassandra/JdbcCassandraResultSet.java
+++ b/src/main/java/com/adaptris/core/cassandra/JdbcCassandraResultSet.java
@@ -2,15 +2,14 @@ package com.adaptris.core.cassandra;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 
 import com.adaptris.jdbc.JdbcResultRow;
 import com.adaptris.jdbc.JdbcResultSet;
 import com.adaptris.jdbc.ParameterValueType;
-import com.datastax.driver.core.ColumnDefinitions;
-import com.datastax.driver.core.ColumnDefinitions.Definition;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
 
 public class JdbcCassandraResultSet implements JdbcResultSet {
 
@@ -38,9 +37,8 @@ public class JdbcCassandraResultSet implements JdbcResultSet {
         JdbcResultRow result = new JdbcResultRow();
 
         ColumnDefinitions columnDefinitions = nextRow.getColumnDefinitions();
-        List<Definition> asList = columnDefinitions.asList();
-        for (Definition definition : asList) {
-          result.setFieldValue(definition.getName(), nextRow.getObject(definition.getName()), (ParameterValueType) null);
+        for (ColumnDefinition definition : columnDefinitions) {
+          result.setFieldValue(definition.getName().asInternal(), nextRow.getObject(definition.getName()), (ParameterValueType) null);
         }
 
         return result;

--- a/src/main/java/com/adaptris/core/cassandra/ResultBuilder.java
+++ b/src/main/java/com/adaptris/core/cassandra/ResultBuilder.java
@@ -2,7 +2,7 @@ package com.adaptris.core.cassandra;
 
 import com.adaptris.jdbc.JdbcResult;
 import com.adaptris.jdbc.JdbcResultSet;
-import com.datastax.driver.core.ResultSet;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
 
 public class ResultBuilder {
 

--- a/src/main/java/com/adaptris/core/cassandra/params/AbstractCassandraParameterApplicator.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/AbstractCassandraParameterApplicator.java
@@ -1,26 +1,27 @@
 package com.adaptris.core.cassandra.params;
 
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 
 public abstract class AbstractCassandraParameterApplicator implements CassandraParameterApplicator {
 
   private transient StatementPrimer statementPrimer;
-  
+
   public AbstractCassandraParameterApplicator() {
-    this.setStatementPrimer(new NullStatementPrimer());
+    setStatementPrimer(new NullStatementPrimer());
   }
-  
-  protected PreparedStatement prepareStatement(Session session, String statement) throws Exception {
-    return this.getStatementPrimer().prepareStatement(session, statement);
+
+  protected PreparedStatement prepareStatement(CqlSession session, String statement) throws Exception {
+    return getStatementPrimer().prepareStatement(session, statement);
   }
 
   public StatementPrimer getStatementPrimer() {
     return statementPrimer;
   }
 
+  @Override
   public void setStatementPrimer(StatementPrimer statementPrimer) {
     this.statementPrimer = statementPrimer;
   }
-  
+
 }

--- a/src/main/java/com/adaptris/core/cassandra/params/CachedStatementPrimer.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/CachedStatementPrimer.java
@@ -5,20 +5,21 @@ import java.util.List;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * This {@link StatementPrimer} will cache a number of CQL statements, therefore not needing to prepare a statement that has
- * already been prepared.
+ * This {@link StatementPrimer} will cache a number of CQL statements, therefore not needing to prepare a statement that has already been
+ * prepared.
  * </p>
  * <p>
  * Use this StatementPrimer when you know you will execute identical statements over and over.
  * </p>
  * <p>
  * Finally you can configure the number of cached statements (the default being 50) by configuring the "cache-limit";
+ *
  * <pre>
  * {@code
  <cached-statement-primer>
@@ -42,21 +43,21 @@ public class CachedStatementPrimer implements StatementPrimer {
   private int cacheLimit;
 
   public CachedStatementPrimer() {
-    setStatements(new ArrayList<PrimedStatement>());
+    setStatements(new ArrayList<>());
     setCacheLimit(50);
   }
 
   @Override
-  public PreparedStatement prepareStatement(Session session, String statement) throws Exception {
+  public PreparedStatement prepareStatement(CqlSession session, String statement) throws Exception {
     int statementIndex = getStatements().indexOf(new PrimedStatement(statement, null));
-    if(statementIndex > -1) {
+    if (statementIndex > -1) {
       return getStatements().get(statementIndex).getPreparedStatement();
     }
 
     PreparedStatement preparedStatement = session.prepare(statement);
 
     PrimedStatement primedStatement = new PrimedStatement(statement, preparedStatement);
-    if(statements.size() >= getCacheLimit()) {
+    if (statements.size() >= getCacheLimit()) {
       getStatements().remove(0);
     }
     getStatements().add(primedStatement);

--- a/src/main/java/com/adaptris/core/cassandra/params/CassandraParameterApplicator.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/CassandraParameterApplicator.java
@@ -3,21 +3,21 @@ package com.adaptris.core.cassandra.params;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.jdbc.StatementParameterCollection;
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 
 /**
  * <p>
  * Implementations of this class define how parameter values will be sourced for Cassandra services.
  * </p>
- * 
+ *
  * @author amcgrath
  *
  */
 public interface CassandraParameterApplicator {
 
-  public BoundStatement applyParameters(Session session, AdaptrisMessage message, StatementParameterCollection parameters, String statement) throws ServiceException;
-  
+  public BoundStatement applyParameters(CqlSession session, AdaptrisMessage message, StatementParameterCollection parameters, String statement) throws ServiceException;
+
   public void setStatementPrimer(StatementPrimer statementPrimer);
-  
+
 }

--- a/src/main/java/com/adaptris/core/cassandra/params/NamedParameterApplicator.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/NamedParameterApplicator.java
@@ -16,9 +16,9 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.jdbc.StatementParameter;
 import com.adaptris.core.services.jdbc.StatementParameterCollection;
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -34,6 +34,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <pre>
  * {@code SELECT * FROM mytable WHERE field1=#param1 AND field2=#param2 AND field3=#param3 AND field4=#param4 AND field5=#param5}
  * </pre>
+ *
  * If you then named your statement parameters as {@code param1, param2, param3, param4, param5} using
  * {@link StatementParameter#setName(String)} then the order of parameters as they appear in configuration no longer matters.
  * </p>
@@ -66,7 +67,7 @@ public class NamedParameterApplicator extends AbstractCassandraParameterApplicat
   }
 
   @Override
-  public BoundStatement applyParameters(Session session, AdaptrisMessage message, StatementParameterCollection parameters, String statement) throws ServiceException {
+  public BoundStatement applyParameters(CqlSession session, AdaptrisMessage message, StatementParameterCollection parameters, String statement) throws ServiceException {
     String formattedStatement = statement.replaceAll(getParameterNameRegex(), "?");
 
     PreparedStatement preparedStatement;
@@ -75,7 +76,6 @@ public class NamedParameterApplicator extends AbstractCassandraParameterApplicat
     } catch (Exception e) {
       throw new ServiceException(e);
     }
-    BoundStatement boundStatement = new BoundStatement(preparedStatement);
 
     Matcher matcher = Pattern.compile(getParameterNameRegex()).matcher(statement);
 
@@ -90,7 +90,7 @@ public class NamedParameterApplicator extends AbstractCassandraParameterApplicat
       foundParameters.add(ParameterHelper.convertToQueryClass(statementParameter.getQueryValue(message), statementParameter.getQueryClass()));
     }
 
-    return boundStatement.bind(foundParameters.toArray());
+    return preparedStatement.bind(foundParameters.toArray());
   }
 
   public String getParameterNamePrefix() {

--- a/src/main/java/com/adaptris/core/cassandra/params/NullParameterApplicator.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/NullParameterApplicator.java
@@ -4,9 +4,9 @@ import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.jdbc.StatementParameterCollection;
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -23,14 +23,14 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 public class NullParameterApplicator extends AbstractCassandraParameterApplicator {
 
   @Override
-  public BoundStatement applyParameters(Session session, AdaptrisMessage message, StatementParameterCollection parameters, String statement) throws ServiceException {
+  public BoundStatement applyParameters(CqlSession session, AdaptrisMessage message, StatementParameterCollection parameters, String statement) throws ServiceException {
     PreparedStatement preparedStatement;
     try {
       preparedStatement = prepareStatement(session, statement);
     } catch (Exception e) {
       throw new ServiceException(e);
     }
-    return new BoundStatement(preparedStatement);
+    return preparedStatement.bind(parameters.toArray());
   }
 
 }

--- a/src/main/java/com/adaptris/core/cassandra/params/NullStatementPrimer.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/NullStatementPrimer.java
@@ -2,14 +2,13 @@ package com.adaptris.core.cassandra.params;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * This {@link StatementPrimer} will simply use your current session object to Cassandra to prepare
- * each statement upon every execution.
+ * This {@link StatementPrimer} will simply use your current session object to Cassandra to prepare each statement upon every execution.
  * </p>
  * <p>
  * Consider using the {@link CachedStatementPrimer} if performance is an issue.
@@ -21,10 +20,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("null-statement-primer")
 @AdapterComponent
 @ComponentProfile(summary = "Prepare each CQL statement upon every execution", tag = "cassandra")
-public class NullStatementPrimer implements StatementPrimer{
+public class NullStatementPrimer implements StatementPrimer {
 
   @Override
-  public PreparedStatement prepareStatement(Session session, String statement) throws Exception {
+  public PreparedStatement prepareStatement(CqlSession session, String statement) throws Exception {
     return session.prepare(statement);
   }
 

--- a/src/main/java/com/adaptris/core/cassandra/params/PrimedStatement.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/PrimedStatement.java
@@ -2,14 +2,14 @@ package com.adaptris.core.cassandra.params;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import com.datastax.driver.core.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 
 public class PrimedStatement {
-  
+
   private String stringStatement;
-  
+
   private PreparedStatement preparedStatement;
-  
+
   public PrimedStatement(String stringStatement, PreparedStatement preparedStatement) {
     setStringStatement(stringStatement);
     setPreparedStatement(preparedStatement);
@@ -17,20 +17,20 @@ public class PrimedStatement {
 
   @Override
   public boolean equals(Object object) {
-    if(object instanceof PrimedStatement) {
+    if (object instanceof PrimedStatement) {
       PrimedStatement other = (PrimedStatement) object;
-      if(other.getStringStatement() != null) {
+      if (other.getStringStatement() != null) {
         return other.getStringStatement().equals(getStringStatement());
       }
     }
     return false;
   }
-  
+
   @Override
   public int hashCode() {
     return new HashCodeBuilder(23, 49).append(getStringStatement()).hashCode();
   }
-  
+
   public String getStringStatement() {
     return stringStatement;
   }

--- a/src/main/java/com/adaptris/core/cassandra/params/SequentialParameterApplicator.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/SequentialParameterApplicator.java
@@ -7,9 +7,9 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.jdbc.JdbcStatementParameter;
 import com.adaptris.core.services.jdbc.StatementParameter;
 import com.adaptris.core.services.jdbc.StatementParameterCollection;
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -29,25 +29,23 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 public class SequentialParameterApplicator extends AbstractCassandraParameterApplicator {
 
   @Override
-  public BoundStatement applyParameters(Session session, AdaptrisMessage message, StatementParameterCollection parameters, String statement) throws ServiceException {
+  public BoundStatement applyParameters(CqlSession session, AdaptrisMessage message, StatementParameterCollection parameters, String statement) throws ServiceException {
     Object[] parameterArray = new Object[parameters.size()];
     int counter = 0;
 
-    for(JdbcStatementParameter jdbcParam : parameters) {
+    for (JdbcStatementParameter jdbcParam : parameters) {
       StatementParameter sParam = (StatementParameter) jdbcParam;
       parameterArray[counter] = ParameterHelper.convertToQueryClass(sParam.getQueryValue(message), sParam.getQueryClass());
-      counter ++;
+      counter++;
     }
 
     PreparedStatement preparedStatement;
     try {
       preparedStatement = prepareStatement(session, statement);
-    } catch (Exception e) {
-      throw new ServiceException(e);
+    } catch (Exception expt) {
+      throw new ServiceException(expt);
     }
-    BoundStatement boundStatement = new BoundStatement(preparedStatement);
-
-    return boundStatement.bind(parameterArray);
+    return preparedStatement.bind(parameterArray);
   }
 
 }

--- a/src/main/java/com/adaptris/core/cassandra/params/StatementPrimer.java
+++ b/src/main/java/com/adaptris/core/cassandra/params/StatementPrimer.java
@@ -1,10 +1,10 @@
 package com.adaptris.core.cassandra.params;
 
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 
 public interface StatementPrimer {
-  
-  public PreparedStatement prepareStatement(Session session, String statement) throws Exception;
+
+  public PreparedStatement prepareStatement(CqlSession session, String statement) throws Exception;
 
 }

--- a/src/test/java/com/adaptris/core/cassandra/CassandraConnectionTest.java
+++ b/src/test/java/com/adaptris/core/cassandra/CassandraConnectionTest.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.cassandra;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class CassandraConnectionTest {
+
+  @Test
+  public void testHostnameAndDefaultPort() throws Exception {
+    CassandraConnection tmpConnection = new CassandraConnection();
+    tmpConnection.setConnectionUrl("localhost");
+
+    assertEquals("localhost", tmpConnection.hostAndPort().getHost());
+  }
+
+  @Test
+  public void testHostnameAndDifferntPort() throws Exception {
+    CassandraConnection tmpConnection = new CassandraConnection();
+    tmpConnection.setConnectionUrl("localhost:9043");
+
+    assertEquals("localhost", tmpConnection.hostAndPort().getHost());
+    assertEquals(9043, tmpConnection.hostAndPort().getPort());
+  }
+
+  @Test
+  public void testHostnameAndInvalidPort() throws Exception {
+    CassandraConnection tmpConnection = new CassandraConnection();
+    tmpConnection.setConnectionUrl("localhost:Invalid");
+
+    assertThrows(IllegalArgumentException.class, () -> tmpConnection.hostAndPort().getHost());
+  }
+
+}

--- a/src/test/java/com/adaptris/core/cassandra/CassandraConnectionTest.java
+++ b/src/test/java/com/adaptris/core/cassandra/CassandraConnectionTest.java
@@ -32,4 +32,24 @@ public class CassandraConnectionTest {
     assertThrows(IllegalArgumentException.class, () -> tmpConnection.hostAndPort().getHost());
   }
 
+  @Test
+  public void testSessionBuilder() throws Exception {
+    CassandraConnection tmpConnection = new CassandraConnection();
+    tmpConnection.setConnectionUrl("localhost");
+
+    // We can't really assert anything but it doesn't fail
+    tmpConnection.sessionBuilder();
+  }
+
+  @Test
+  public void testSessionBuilderWithCredentials() throws Exception {
+    CassandraConnection tmpConnection = new CassandraConnection();
+    tmpConnection.setConnectionUrl("localhost");
+    tmpConnection.setUsername("username");
+    tmpConnection.setPassword("password");
+
+    // We can't really assert anything but it doesn't fail
+    tmpConnection.sessionBuilder();
+  }
+
 }

--- a/src/test/java/com/adaptris/core/cassandra/CassandraExecuteServiceTest.java
+++ b/src/test/java/com/adaptris/core/cassandra/CassandraExecuteServiceTest.java
@@ -2,6 +2,7 @@ package com.adaptris.core.cassandra;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumingThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ public class CassandraExecuteServiceTest extends CassandraCase {
 
   @Test
   public void testSimpleInsert() throws Exception {
-    if (testsEnabled) {
+    assumingThat(testsEnabled, () -> {
       ConstantDataInputParameter insertStatement = new ConstantDataInputParameter(
           "insert into liverpool_transfers(player, amount, club, manager) "
               + "values ('Fred', 10, 'Accrington Stanley', 'Brendan Rogers')");
@@ -66,12 +67,12 @@ public class CassandraExecuteServiceTest extends CassandraCase {
       shutdown(service, verifyService);
 
       assertEquals("Accrington Stanley", message.getMetadataValue("Cassandra_club"));
-    }
+    });
   }
 
   @Test
   public void testSimpleInsertAndDelete() throws Exception {
-    if (testsEnabled) {
+    assumingThat(testsEnabled, () -> {
       ConstantDataInputParameter deleteStatement = new ConstantDataInputParameter("delete from liverpool_transfers where player = 'Fred'");
 
       ConstantDataInputParameter insertStatement = new ConstantDataInputParameter(
@@ -97,12 +98,12 @@ public class CassandraExecuteServiceTest extends CassandraCase {
       assertNull(deleteServiceMessage.getMetadataValue("Cassandra_club"));
 
       shutdown(service, verifyService);
-    }
+    });
   }
 
   @Test
   public void testSimpleInsertWithParameters() throws Exception {
-    if (testsEnabled) {
+    assumingThat(testsEnabled, () -> {
       ConstantDataInputParameter insertStatement = new ConstantDataInputParameter(
           "insert into liverpool_transfers(player, amount, club, manager) values (?, ?, ?, ?)");
       message.addMessageHeader("player", "Fred");
@@ -152,7 +153,7 @@ public class CassandraExecuteServiceTest extends CassandraCase {
       assertEquals("Accrington Stanley", message.getMetadataValue("Cassandra_club"));
       assertEquals("10", message.getMetadataValue("Cassandra_amount"));
       assertEquals("Brendan Rogers", message.getMetadataValue("Cassandra_manager"));
-    }
+    });
   }
 
   @Override

--- a/src/test/java/com/adaptris/core/cassandra/CassandraQueryServiceTest.java
+++ b/src/test/java/com/adaptris/core/cassandra/CassandraQueryServiceTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.core.cassandra;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumingThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ public class CassandraQueryServiceTest extends CassandraCase {
 
   @Test
   public void testSimpleValueQuery() throws Exception {
-    if (testsEnabled) {
+    assumingThat(testsEnabled, () -> {
       service.setStatement(new ConstantDataInputParameter("select club from liverpool_transfers where player = 'Xabi Alonso'"));
 
       startup(service);
@@ -52,14 +53,12 @@ public class CassandraQueryServiceTest extends CassandraCase {
       shutdown(service);
 
       assertEquals("Real Sociedad", message.getMetadataValue("Cassandra_club"));
-    } else {
-      System.out.println("Skipping testSimpleValueQuery()");
-    }
+    });
   }
 
   @Test
   public void testSimpleRowQuery() throws Exception {
-    if (testsEnabled) {
+    assumingThat(testsEnabled, () -> {
       service.setStatement(new ConstantDataInputParameter("select * from liverpool_transfers where player = 'Xabi Alonso'"));
 
       startup(service);
@@ -70,14 +69,12 @@ public class CassandraQueryServiceTest extends CassandraCase {
       assertEquals("10700000", message.getMetadataValue("Cassandra_amount"));
       assertEquals("Rafael Benitez", message.getMetadataValue("Cassandra_manager"));
       assertEquals("Xabi Alonso", message.getMetadataValue("Cassandra_player"));
-    } else {
-      System.out.println("Skipping testSimpleRowQuery()");
-    }
+    });
   }
 
   @Test
   public void testSimpleValueQueryWithSimpleParameter() throws Exception {
-    if (testsEnabled) {
+    assumingThat(testsEnabled, () -> {
       service.setStatement(new ConstantDataInputParameter("select club from liverpool_transfers where player = ?"));
 
       StatementParameter parameter = new StatementParameter();
@@ -95,14 +92,12 @@ public class CassandraQueryServiceTest extends CassandraCase {
       shutdown(service);
 
       assertEquals("Real Sociedad", message.getMetadataValue("Cassandra_club"));
-    } else {
-      System.out.println("Skipping testSimpleValueQueryWithSimpleParameter()");
-    }
+    });
   }
 
   @Test
   public void testSimpleValueQueryWithNamedParameter() throws Exception {
-    if (testsEnabled) {
+    assumingThat(testsEnabled, () -> {
       service.setStatement(new ConstantDataInputParameter("select club from liverpool_transfers where player = #playername"));
 
       StatementParameter parameter = new StatementParameter();
@@ -121,9 +116,7 @@ public class CassandraQueryServiceTest extends CassandraCase {
       shutdown(service);
 
       assertEquals("Real Sociedad", message.getMetadataValue("Cassandra_club"));
-    } else {
-      System.out.println("Skipping testSimpleValueQueryWithNamedParameter()");
-    }
+    });
   }
 
   @Override

--- a/src/test/java/com/adaptris/core/cassandra/params/CachedStatementPrimerTest.java
+++ b/src/test/java/com/adaptris/core/cassandra/params/CachedStatementPrimerTest.java
@@ -11,13 +11,13 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.adaptris.interlok.util.Closer;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 
 public class CachedStatementPrimerTest {
 
   @Mock
-  private Session mockSession;
+  private CqlSession mockSession;
 
   @Mock
   private PreparedStatement mockPreparedStatement;


### PR DESCRIPTION
## Motivation

To use the latest version of Cassandra

## Modification

- Upgrade cassandra to 4.17.0
- Add option to change the port when setting the connectUrl (hostname:port). For backward compatibility if the port is not provided the default port '9042' will be used.
- Add a new option to set the datacenter name which is now required by the new Cassandra API. For backward compatibility if left blank the considered default 'datacenter1' will be used.
- Only add the auth credentials if the username and the password are not empty.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked the display of the component in the UI

## Result

No real change for the end user.

## Testing

The build should pass with cassandra test enabled.
You can test the jar file from this PR with https://github.com/interlok-testing/testing_cassandra.
You will also need to add to the build.gradle:
```
  interlokRuntime ("com.datastax.oss:java-driver-core:4.17.0")
  interlokRuntime ("com.datastax.oss:java-driver-mapper-runtime:4.17.0")
```
